### PR TITLE
Support specifying the ssl_policy

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -17,7 +17,7 @@ resource "aws_alb_listener" "alb_listener" {
   load_balancer_arn = "${aws_alb.alb.arn}"
   port              = "${var.listener_port}"
   protocol          = "${var.listener_protocol}"
-  ssl_policy        = "${lookup(map("HTTP", ""), var.listener_protocol, "ELBSecurityPolicy-2015-05")}"
+  ssl_policy        = "${var.listener_ssl_policy != "" ? var.listener_ssl_policy : lookup(map("HTTP", ""), var.listener_protocol, "ELBSecurityPolicy-2015-05")}"
   certificate_arn   = "${var.listener_certificate_arn}"
 
   default_action = {

--- a/variables.tf
+++ b/variables.tf
@@ -44,6 +44,11 @@ variable "listener_certificate_arn" {
   default = ""
 }
 
+variable "listener_ssl_policy" {
+  type = "string"
+  default = ""
+}
+
 // The port that the default target group will pass requests to.
 variable "default_target_group_port" {
   type    = "string"


### PR DESCRIPTION
This is important for us, as our compliance requirements mandate that we
do not support older versions of TLS like 1.0.